### PR TITLE
BindingInfo.ToString() prints value hashcode

### DIFF
--- a/src/Assets/Adic/Scripts/Framework/Binding/BindingInfo.cs
+++ b/src/Assets/Adic/Scripts/Framework/Binding/BindingInfo.cs
@@ -49,7 +49,7 @@ namespace Adic.Binding {
 				"Conditions: {5}\n",
 				this.type.FullName,
 				(this.value == null ? "-" : this.value.ToString()),
-				(this.value is Type ? "type" : "instance"),
+				(this.value is Type ? "type" : "instance [" + this.GetHashCode() + "]"),
 				this.instanceType.ToString(),
 				(this.identifier == null ? "-" : this.identifier.ToString()),
 				(this.condition == null ? "no" : "yes")


### PR DESCRIPTION
I have modified BindingInfo.ToString() to include the hashcode of the value object so it's displayed in the  Bindings Printer.  This was useful in tracking down an issue where I had two different instances bound to similar types.