### PR TITLE
Added includeChildren param to ToNamespace and ToNamespaceSingleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,9 @@ Binds the key type to all assignable types in a given namespace as transient bin
 
 ```cs
 container.Bind<SomeType>().ToNamespace("MyNamespace.Whatever");
+
+// Includes children namespaces
+container.Bind<SomeType>().ToNamespace("MyNamespace.Whatever", true);
 ```
 
 #### To all types in a namespace as singleton
@@ -413,6 +416,9 @@ Binds the key type to all assignable types in a given namespace as singleton bin
 
 ```cs
 container.Bind<SomeType>().ToNamespaceSingleton("MyNamespace.Whatever");
+
+// Includes children namespaces
+container.Bind<SomeType>().ToNamespaceSingleton("MyNamespace.Whatever", true);
 ```
 
 #### To a Factory

--- a/src/Assets/Adic/Scripts/Framework/Binding/BindingFactory.cs
+++ b/src/Assets/Adic/Scripts/Framework/Binding/BindingFactory.cs
@@ -3,17 +3,17 @@ using Adic.Exceptions;
 using Adic.Util;
 
 namespace Adic.Binding {
-	//// <summary>
+	/// <summary>
 	/// Binding types to another types or instances.
 	/// </summary>
 	public class BindingFactory : IBindingFactory {
-		//// <summary>Binder used by the Binding Factory.</summary>
+		/// <summary>Binder used by the Binding Factory.</summary>
 		public IBinder binder { get; private set; }
-		//// <summary>The type being bound.</summary>
+		/// <summary>The type being bound.</summary>
 		public Type bindingType { get; private set; }
 		
-		//// <summary>
-		/// Initializes a new instance of the <see cref="Adic.BindingFactory"/> class.
+		/// <summary>
+		/// Initializes a new instance of the <see cref="BindingFactory"/> class.
 		/// </summary>
 		/// <param name="bindingType">The type being bound.</param>
 		/// <param name="binder">The binder that will bind this binding.</param>
@@ -22,7 +22,7 @@ namespace Adic.Binding {
 			this.binder = binder;
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a transient of itself. The key must be a class.
 		/// </summary>
 		/// <returns>The binding condition object related to this binding.</returns>
@@ -30,7 +30,7 @@ namespace Adic.Binding {
 			return this.AddBinding(this.bindingType, BindingInstance.Transient);
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a singleton of itself. The key must be a class.
 		/// </summary>
 		/// <returns>The binding condition object related to this binding.</returns>
@@ -38,7 +38,7 @@ namespace Adic.Binding {
 			return this.AddBinding(this.bindingType, BindingInstance.Singleton);
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a singleton of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The related type.</typeparam>
@@ -47,7 +47,7 @@ namespace Adic.Binding {
 			return this.ToSingleton(typeof(T));
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a singleton of type <paramref name="type"/>.
 		/// </summary>
 		/// <param name="type">The related type.</param>
@@ -60,7 +60,7 @@ namespace Adic.Binding {
 			return this.AddBinding(type, BindingInstance.Singleton);
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a transient of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The type to bind to.</typeparam>
@@ -69,7 +69,7 @@ namespace Adic.Binding {
 			return this.To(typeof(T));
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a transient of type <paramref name="type"/>.
 		/// </summary>
 		/// <param name="type">The related type.</param>
@@ -82,7 +82,7 @@ namespace Adic.Binding {
 			return this.AddBinding(type, BindingInstance.Transient);
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to an <paramref name="instance"/>.
 		/// </summary>
 		/// <typeparam name="T">The related type.</typeparam>
@@ -92,10 +92,10 @@ namespace Adic.Binding {
 			return this.To(typeof(T), instance);
 		}
 
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to an <paramref name="instance"/>.
 		/// </summary>
-		/// <param name="type">The related type.</typeparam>
+		/// <param name="type">The related type.</param>
 		/// <param name="instance">The instance to bind the type to.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
 		public IBindingConditionFactory To(Type type, object instance) {
@@ -115,28 +115,52 @@ namespace Adic.Binding {
 		/// <param name="namespaceName">Namespace name.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
         public IBindingConditionFactory ToNamespace(string namespaceName) {
-            return ToNamespace(namespaceName, BindingInstance.Transient);
+            return this.ToNamespace(namespaceName, BindingInstance.Transient, false);
 		}
-		
+
+		/// <summary>
+		/// Binds the key type to all assignable types in a given <paramref name="namespaceName"/> 
+		/// as transient bindings.
+		/// </summary>
+		/// <param name="namespaceName">Namespace name.</param>
+		/// <param name="includeChildren">Indicates whether child namespaces should be included.</param>
+		/// <returns>The binding condition object related to this binding.</returns>
+		public IBindingConditionFactory ToNamespace(string namespaceName, bool includeChildren)
+		{
+			return this.ToNamespace(namespaceName, BindingInstance.Transient, includeChildren);
+		}
+
 		/// <summary>
 		/// Binds the key type to all assignable types in a given <paramref name="namespaceName"/>
 		/// as singleton bindings.
 		/// </summary>
 		/// <param name="namespaceName">Namespace name.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
-        public IBindingConditionFactory ToNamespaceSingleton(string namespaceName) {
-            return ToNamespace(namespaceName, BindingInstance.Singleton);
+		public IBindingConditionFactory ToNamespaceSingleton(string namespaceName) {
+            return this.ToNamespace(namespaceName, BindingInstance.Singleton, false);
         }
 
-        /// <summary>
-        /// Binds the key type to all assignable types in a given <paramref name="namespaceName"/>
-        /// as singleton bindings.
-        /// </summary>
-        /// <param name="namespaceName">Namespace name.</param>
-        /// <param name="bindingInstance">Binding instance type.</param>.</param>
-        /// <returns>The binding condition object related to this binding.</returns>
-        protected IBindingConditionFactory ToNamespace(string namespaceName, BindingInstance bindingInstance) {
-            var types = TypeUtils.GetAssignableTypes(this.bindingType, namespaceName);
+		/// <summary>
+		/// Binds the key type to all assignable types in a given <paramref name="namespaceName"/>
+		/// as singleton bindings.
+		/// </summary>
+		/// <param name="namespaceName">Namespace name.</param>
+		/// <param name="includeChildren">Indicates whether child namespaces should be included.</param>
+		/// <returns>The binding condition object related to this binding.</returns>
+		public IBindingConditionFactory ToNamespaceSingleton(string namespaceName, bool includeChildren)
+		{
+			return this.ToNamespace(namespaceName, BindingInstance.Singleton, false);
+		}
+		/// <summary>
+		/// Binds the key type to all assignable types in a given <paramref name="namespaceName"/>
+		/// as singleton bindings.
+		/// </summary>
+		/// <param name="namespaceName">Namespace name.</param>
+		/// <param name="bindingInstance">Binding instance type.</param>.
+		/// <param name="includeChildren">Indicates whether child namespaces should be included.</param>
+		/// <returns>The binding condition object related to this binding.</returns>
+		protected IBindingConditionFactory ToNamespace(string namespaceName, BindingInstance bindingInstance, bool includeChildren) {
+            var types = TypeUtils.GetAssignableTypes(this.bindingType, namespaceName, includeChildren);
 
             IBindingConditionFactory[] bindingConditionFactories = new IBindingConditionFactory[types.Length];
             for (int typeIndex = 0; typeIndex < types.Length; typeIndex++) {
@@ -146,7 +170,7 @@ namespace Adic.Binding {
             return this.CreateBindingConditionFactoryProvider(bindingConditionFactories);
         }
 
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a <typeparamref name="T"/> factory.
 		/// </summary>
 		/// <typeparam name="T">The factory type.</typeparam>
@@ -155,10 +179,10 @@ namespace Adic.Binding {
 			return this.ToFactory(typeof(T));
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a factory of a certain <paramref name="type"/>.
 		/// </summary>
-		/// <param name="type">The factory type.</typeparam>
+		/// <param name="type">The factory type.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
 		public IBindingConditionFactory ToFactory(Type type) {
 			if (!TypeUtils.IsAssignable(typeof(IFactory), type)) {
@@ -168,7 +192,7 @@ namespace Adic.Binding {
 			return this.AddBinding(type, BindingInstance.Factory);
 		}
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a <paramref name="factory"/>.
 		/// </summary>
 		/// <param name="factory">Factory to be bound to.</param>
@@ -177,7 +201,7 @@ namespace Adic.Binding {
 			return this.AddBinding(factory, BindingInstance.Factory);
 		}
 
-		//// <summary>
+		/// <summary>
 		/// Adds a binding.
 		/// </summary>
 		/// <param name="value">Binding value.</param>
@@ -190,16 +214,16 @@ namespace Adic.Binding {
 			return this.CreateBindingConditionFactoryProvider(binding);
         }
 		
-		//// <summary>
+		/// <summary>
 		/// Resolves the binding provider.
 		/// </summary>
-		/// <param name="type">The type being bound.</param>
+		/// <param name="binding">Informatiion about the binding.</param>
 		/// <returns>The binding provider.</returns>
 		protected virtual IBindingConditionFactory CreateBindingConditionFactoryProvider(BindingInfo binding) {
 			return new SingleBindingConditionFactory(binding, this.binder);
         }
 
-        //// <summary>
+        /// <summary>
         /// Resolves the binding provider.
         /// </summary>
         /// <param name="bindingConditionFactories">Binding factories.</param>

--- a/src/Assets/Adic/Scripts/Framework/Binding/IBindingFactory.cs
+++ b/src/Assets/Adic/Scripts/Framework/Binding/IBindingFactory.cs
@@ -1,51 +1,51 @@
 using System;
 
 namespace Adic.Binding {
-	//// <summary>
+	/// <summary>
 	/// Defines a binding factory.
 	/// 
 	/// The binding factory also provides binding capabilities for chaining.
 	/// </summary>
 	public interface IBindingFactory {
-		//// <summary>Binder used by the Binding Factory.</summary>
+		/// <summary>Binder used by the Binding Factory.</summary>
 		IBinder binder { get; }
-		//// <summary>The type being bound.</summary>
+		/// <summary>The type being bound.</summary>
 		Type bindingType { get; }
 
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a transient of itself. The key must be a class. 
 		/// </summary>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory ToSelf();
 
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a singleton of itself. The key must be a class.
 		/// </summary>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory ToSingleton();
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a singleton of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The related type.</typeparam>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory ToSingleton<T>() where T : class;
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a singleton of type <paramref name="type"/>.
 		/// </summary>
 		/// <param name="type">The related type.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory ToSingleton(Type type);
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a transient of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The type to bind to.</typeparam>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory To<T>() where T : class;
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a transient of type <paramref name="type"/>.
 		/// </summary>
 		/// <param name="type">The related type.</param>
@@ -60,10 +60,10 @@ namespace Adic.Binding {
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory To<T>(T instance);
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to an <paramref name="instance"/>.
 		/// </summary>
-		/// <param name="type">The related type.</typeparam>
+		/// <param name="type">The related type.</param>
 		/// <param name="instance">The instance to bind the type to.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory To(Type type, object instance);
@@ -75,37 +75,55 @@ namespace Adic.Binding {
 		/// <param name="namespaceName">Namespace name.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
         IBindingConditionFactory ToNamespace(string namespaceName);
-		
+
+		/// <summary>
+		/// Binds the key type to all assignable types in a given <paramref name="namespaceName"/> 
+		/// as transient bindings.
+		/// </summary>
+		/// <param name="namespaceName">Namespace name.</param>
+		/// <param name="includeChildren">Indicates whether child namespaces should be included.</param>
+		/// <returns>The binding condition object related to this binding.</returns>
+		IBindingConditionFactory ToNamespace(string namespaceName, bool includeChildren);
+
 		/// <summary>
 		/// Binds the key to all assignable types in a given <paramref name="namespaceName"/>
 		/// as singleton bindings.
 		/// </summary>
 		/// <param name="namespaceName">Namespace name.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
-        IBindingConditionFactory ToNamespaceSingleton(string namespaceName);
-		
-		//// <summary>
+		IBindingConditionFactory ToNamespaceSingleton(string namespaceName);
+
+		/// <summary>
+		/// Binds the key to all assignable types in a given <paramref name="namespaceName"/>
+		/// as singleton bindings.
+		/// </summary>
+		/// <param name="namespaceName">Namespace name.</param>
+		/// <param name="includeChildren">Indicates whether child namespaces should be included.</param>
+		/// <returns>The binding condition object related to this binding.</returns>
+		IBindingConditionFactory ToNamespaceSingleton(string namespaceName, bool includeChildren);
+
+		/// <summary>
 		/// Binds the key type to a <typeparamref name="T"/> factory.
 		/// </summary>
 		/// <typeparam name="T">The factory type.</typeparam>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory ToFactory<T>() where T : IFactory;
 		
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a factory of a certain <paramref name="type"/>.
 		/// </summary>
-		/// <param name="type">The factory type.</typeparam>
+		/// <param name="type">The factory type.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory ToFactory(Type type);
 
-		//// <summary>
+		/// <summary>
 		/// Binds the key type to a <paramref name="factory"/>.
 		/// </summary>
 		/// <param name="factory">Factory to be bound to.</param>
 		/// <returns>The binding condition object related to this binding.</returns>
 		IBindingConditionFactory ToFactory(IFactory factory);
 
-		//// <summary>
+		/// <summary>
 		/// Creates a binding.
 		/// </summary>
 		/// <returns>The binding.</returns>


### PR DESCRIPTION
Seeing as `TypeUtils.GetAssignableTypes` supported the includeChildren parameter it made sense to expose this functionality in the `ToNamespace` and `ToNamespaceSingleton` calls.  I also did a quick cleanup of the documentation while I was in there.