### PR TITLE
Allow arrays to be resolved as empty

### DIFF
--- a/src/Assets/Adic/Scripts/Framework/Injection/Injector.cs
+++ b/src/Assets/Adic/Scripts/Framework/Injection/Injector.cs
@@ -231,7 +231,9 @@ namespace Adic.Injection {
 
 			if (bindings == null) {
 				if (alwaysResolve || this.resolutionMode == ResolutionMode.ALWAYS_RESOLVE) {
-                    instances.Add(this.Instantiate(typeToGet));
+					if (!type.IsArray) {
+						instances.Add(this.Instantiate(typeToGet));
+					}
 				} else {
 					return null;
 				}
@@ -249,7 +251,7 @@ namespace Adic.Injection {
 			
 			if (type != null && !type.IsArray && instances.Count == 1) {
 				resolution = instances[0];
-			} else if (instances.Count > 0) {
+			} else if (type.IsArray) {
 				var array = Array.CreateInstance(typeToGet, instances.Count);
 				for (int listIndex = 0; listIndex < instances.Count; listIndex++) {
 					array.SetValue(instances[listIndex], listIndex);

--- a/src/Assets/Adic/Scripts/Framework/Injection/Injector.cs
+++ b/src/Assets/Adic/Scripts/Framework/Injection/Injector.cs
@@ -231,7 +231,7 @@ namespace Adic.Injection {
 
 			if (bindings == null) {
 				if (alwaysResolve || this.resolutionMode == ResolutionMode.ALWAYS_RESOLVE) {
-					if (!type.IsArray) {
+					if (!(typeToGet.IsInterface && type.IsArray)) {
 						instances.Add(this.Instantiate(typeToGet));
 					}
 				} else {


### PR DESCRIPTION
I wasn't too sure about this one but wanted to make a pull request for it anyway.  With the current implementation of Adic the following code causes a `InjectorException: Interface "TestGameRoot+IMockInterface" cannot be instantiated.` exception:

```
using Adic;

public class TestGameRoot : ContextRoot {
	[Inject] private IMockInterface[] Test;

	public override void SetupContainers()	{
		var container = this.AddContainer<InjectionContainer>();
		container.resolutionMode = ResolutionMode.ALWAYS_RESOLVE;
		container.Bind<IMockInterface>().ToNamespace("", true);
		this.Inject();
	}

	public override void Init() {}

	public interface IMockInterface {}
}
```

I understand the reasoning behind the error but I feel that in this situation the end result for the Test property should be an empty array (ie: `private IMockInterface[] Test = new IMockInterface[0]`)  This would fulfill the `ALWAYS_RESOLVE` requirement (I have a property that has been resolved) while still fitting in with my configuration (no `IMockInterface` classes defined).  This pull request accomplishes that functionality.

This situation has come up because I have platform-specific classes bound to `IMockInterface`, and in some cases the platform doesn't need an `IMockInterface` definition.  Currently I need to create a fake class like `public class NullClass : IMockInterface` to have my game run and that doesn't seem correct.

If you would like more details let me know.