### PR TITLE
Fix exception when trying create instance of interface that not bind

### DIFF
--- a/src/Assets/Adic/Scripts/Framework/Injection/Injector.cs
+++ b/src/Assets/Adic/Scripts/Framework/Injection/Injector.cs
@@ -236,7 +236,7 @@ namespace Adic.Injection {
 
             if (bindings == null) {
                 if (alwaysResolve || this.resolutionMode == ResolutionMode.ALWAYS_RESOLVE) {
-                    if (!(typeToGet.IsInterface && type.IsArray)) {
+                    if (!(typeToGet.IsInterface) && !(type.IsArray)) {
                         instances.Add(this.Instantiate(typeToGet));
                     }
                 } else {


### PR DESCRIPTION
When resolve interface, that wasn't bind, injector.cs throws exception. As I see, this bug came from [Allow arrays to be resolved as empty #83](https://github.com/intentor/adic/pull/83)

Code exemple

```
    public class TestContext : ContextRoot
    {
        private IInjectionContainer levelContainer;
        public override void SetupContainers()
        {
            levelContainer = AddContainer(new InjectionContainer("Level"));
        }
        public override void Init()
        {
            levelContainer.Resolve<ITest[]>();
        }
    }
```