### PR TITLE
Added the ability to copy the bindings printer text to clipboard.

### DIFF
--- a/src/Assets/Adic/Scripts/Extensions/BindingsPrinter/Editor/BindingsPrinterWindow.cs
+++ b/src/Assets/Adic/Scripts/Extensions/BindingsPrinter/Editor/BindingsPrinterWindow.cs
@@ -1,6 +1,6 @@
-﻿using UnityEngine;
+﻿using System.Text;
+using UnityEngine;
 using UnityEditor;
-using Adic;
 
 namespace Adic.Extenstions.BindingsPrinter {
     /// <summary>
@@ -44,11 +44,15 @@ namespace Adic.Extenstions.BindingsPrinter {
             GUILayout.Space(WINDOW_MARGIN);
             GUILayout.BeginVertical();
 			
-            this.scrollPosition = GUILayout.BeginScrollView(scrollPosition);
+            this.scrollPosition = GUILayout.BeginScrollView(this.scrollPosition);
 
             GUILayout.Space(WINDOW_MARGIN);
             GUILayout.Label("Adic Bindings Printer", EditorStyles.title);
             GUILayout.Label("Displays all bindings of all available containers", EditorStyles.containerInfo);            
+
+            if (GUILayout.Button("Copy to clipboard")) {
+                this.CopyToClipboard();
+            }
 
             // Display the containers and their bindings.
             for (int dataIndex = 0; dataIndex < ContextRoot.containersData.Count; dataIndex++) {
@@ -85,6 +89,29 @@ namespace Adic.Extenstions.BindingsPrinter {
             GUILayout.EndScrollView();
             GUILayout.EndVertical();
             GUILayout.EndHorizontal();
+        }
+
+        private void CopyToClipboard()
+        {
+            var sb = new StringBuilder();
+
+            for (int dataIndex = 0; dataIndex < ContextRoot.containersData.Count; dataIndex++) {
+                var data = ContextRoot.containersData[dataIndex];
+                var bindings = data.container.GetBindings();
+                sb.AppendFormat("[{1}] {0} ({2} | {3})\n", data.container.GetType().FullName, dataIndex,
+                    data.container.identifier, data.destroyOnLoad ? "destroy on load" : "singleton");
+
+                for (int bindingIndex = 0; bindingIndex < bindings.Count; bindingIndex++) {
+                    var binding = bindings[bindingIndex];
+
+                    sb.AppendLine(binding.ToString());
+                }
+            }
+
+            var te = new TextEditor();
+            te.text = sb.ToString();
+            te.SelectAll();
+            te.Copy();
         }
     }
 }


### PR DESCRIPTION
I wanted to search the bindings list and wrote a quick-and-dirty way to do so.  Now I can copy the text to my clipboard, paste it in notepad and search.  It would be better to have this integrated directly into the bindings window but this was enough for my needs.